### PR TITLE
fix issue where a path to the openproject instance is overwritten

### DIFF
--- a/components/requests/requests.go
+++ b/components/requests/requests.go
@@ -42,7 +42,7 @@ func Do(method string, path string, query *Query, requestData *RequestData) (res
 	}
 
 	requestUrl := *host
-	requestUrl.Path = path
+	requestUrl.Path += path
 	if query != nil {
 		requestUrl.RawQuery = query.String()
 	}


### PR DESCRIPTION
The current implementation add "/api/v3" to the host URL and overwrites the path to the instance. So, if the URL of the instance is:

https://host.de/openproject

the request will go to 

https://host.de/api/v3

instead of

https://host.de/openproject/api/v3