### PR TITLE
Add helper note on MacOS quarantine for "unknown" executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ OpenProject CLI: X.Y.Z
         built with: go1.20.5
 ```
 
+> MacOS will place the executable in quarantine by default. If your Mac displays an alert when you run the executable, you can dequarantine the `op` executable via the following command:
+
+```shell
+xattr -d com.apple.quarantine /usr/local/bin/op
+```
+
 ### Go toolchain
 
 If you already have the Go toolchain installed on your system, you can install the OpenProject CLI with the `go install`


### PR DESCRIPTION
https://support.apple.com/en-is/102445

> MacOS will place the executable in quarantine by default. If your Mac displays an alert when you run the executable, you can dequarantine the `op` executable via the following command:

```shell
xattr -d com.apple.quarantine /usr/local/bin/op
```

<img width="372" alt="Screenshot 2024-12-18 at 11 19 48 AM" src="https://github.com/user-attachments/assets/7ac946bc-f3eb-4811-9809-8ea6fbf6cbcb" />
