### PR TITLE
Fix login to support auth-required OpenProject instances

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -63,7 +64,7 @@ func login(_ *cobra.Command, _ []string) {
 	}
 
 	for {
-		fmt.Printf("OpenProject API Token (Visit %s/my/access_token to generate one): ", hostUrl)
+		fmt.Printf("OpenProject API Token (Visit %s/my/access_tokens to generate one): ", hostUrl)
 		ok, t := requestApiToken()
 		if !ok {
 			fmt.Println(tokenInputError)
@@ -128,14 +129,29 @@ func parseHostUrl() (ok bool, errMessage string, host *url.URL) {
 func checkOpenProjectApi() bool {
 	printer.Debug(Verbose, "Fetching API root to check for instance configuration ...")
 
-	response, err := requests.Get(paths.Root(), nil)
+	statusCode, header, body, err := requests.Probe(paths.Root())
 	if err != nil {
+		printer.Debug(Verbose, fmt.Sprintf("Error probing OpenProject API: %+v", err))
 		return false
 	}
 
-	c := parser.Parse[dtos.ConfigDto](response)
+	// Public instance: standard check on the root resource
+	if statusCode == http.StatusOK {
+		c := parser.Parse[dtos.ConfigDto](body)
+		return c.Type == "Root" && len(c.InstanceName) > 0
+	}
 
-	return c.Type == "Root" && len(c.InstanceName) > 0
+	// Auth-required instance: detect OpenProject via the Link header added before authentication
+	if statusCode == http.StatusUnauthorized {
+		linkHeader := header.Get("Link")
+		if strings.Contains(linkHeader, "/api/v3/openapi.json") {
+			return true
+		}
+		// Fallback: check error body for OpenProject-specific error identifier
+		return strings.Contains(string(body), "openproject-org")
+	}
+
+	return false
 }
 
 func requestApiToken() (ok bool, token string) {

--- a/components/requests/requests.go
+++ b/components/requests/requests.go
@@ -107,6 +107,35 @@ func Do(method string, path string, query *Query, requestData *RequestData) (res
 	return response, nil
 }
 
+// Probe performs a GET request and returns the raw response without treating
+// non-2xx status codes as errors. Used for instance detection before authentication.
+func Probe(path string) (statusCode int, header http.Header, body []byte, err error) {
+	if client == nil || hostUnitialised() {
+		return 0, nil, nil, errors.Custom("Cannot execute requests without initializing request client first. Run `op login`")
+	}
+
+	requestUrl := *host
+	requestUrl.Path += path
+
+	request, err := http.NewRequest("GET", requestUrl.String(), nil)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	resp, err := client.Do(request)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	return resp.StatusCode, resp.Header, responseBody, nil
+}
+
 func isSuccess(code int) bool {
 	return code >= 200 && code <= 299
 }


### PR DESCRIPTION
Currently, logging in on an OpenProject instance which requires auth fails with an error:

```
./op --verbose login
[DEBUG] Parsing host URL ...
OpenProject host URL: https://someinstance.openproject.eu/
[DEBUG] Parsed input "https://someinstance.openproject.eu\n".
[DEBUG] Sanitizing input ...
[DEBUG] Sanitized input 'https://someinstance.openproject.eu/'.
[DEBUG] Parsing input as url ...
[DEBUG] Parsed url 'https://someinstance.openproject.eu/'.
[DEBUG] Checking for http host and scheme ...
[DEBUG] Parsing input successful, continuing with next steps.
[DEBUG] Initializing requests client ...
[DEBUG] Fetching API root to check for instance configuration ...
[DEBUG] Building HTTP request:
[DEBUG] with Method: GET
[DEBUG] with Path: /api/v3
[DEBUG] with Query:
[DEBUG] with Body:
[DEBUG] Running HTTP request GET https://someinstance.openproject.eu/api/v3
[ERROR] URL does not point to a valid OpenProject instance.
```

This happens because the `/api/v3` replies with 401.

This PR fixes this issue:

- Add requests.Probe() to perform unauthenticated HTTP requests without treating non-2xx responses as errors
- Update checkOpenProjectApi() to accept 401 responses from instances that require authentication on /api/v3, detecting OpenProject via the Link header or error identifier
- Fix API token URL from /my/access_token to /my/access_tokens
