### PR TITLE
Fix work package list alignment with accented characters

### DIFF
--- a/components/printer/work_packages.go
+++ b/components/printer/work_packages.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/opf/openproject-cli/components/common"
 	"github.com/opf/openproject-cli/components/routes"
@@ -16,8 +17,8 @@ func WorkPackages(workPackages []*models.WorkPackage) {
 	var maxStatusLength = 0
 	for _, w := range workPackages {
 		maxIdLength = common.Max(maxIdLength, idLength(w.Id))
-		maxTypeLength = common.Max(maxTypeLength, len(w.Type))
-		maxStatusLength = common.Max(maxStatusLength, len(w.Status))
+		maxTypeLength = common.Max(maxTypeLength, utf8.RuneCountInString(w.Type))
+		maxStatusLength = common.Max(maxStatusLength, utf8.RuneCountInString(w.Status))
 	}
 
 	for _, workPackage := range workPackages {
@@ -26,7 +27,7 @@ func WorkPackages(workPackages []*models.WorkPackage) {
 }
 
 func WorkPackage(workPackage *models.WorkPackage) {
-	printHeadline(workPackage, idLength(workPackage.Id), 0, len(workPackage.Type))
+	printHeadline(workPackage, idLength(workPackage.Id), 0, utf8.RuneCountInString(workPackage.Type))
 	printAttributes(workPackage)
 	activePrinter.Println()
 	printOpenLink(workPackage)
@@ -45,12 +46,12 @@ func printHeadline(workPackage *models.WorkPackage, maxIdLength, maxStatusLength
 	idStr := fmt.Sprintf("%s#%d", indent(diff), workPackage.Id)
 	parts = append(parts, Red(idStr))
 
-	diff = maxTypeLength - len(workPackage.Type)
+	diff = maxTypeLength - utf8.RuneCountInString(workPackage.Type)
 	typeStr := strings.ToUpper(workPackage.Type) + indent(diff)
 	parts = append(parts, Green(typeStr))
 
 	if maxStatusLength > 0 {
-		diff = maxStatusLength - len(workPackage.Status)
+		diff = maxStatusLength - utf8.RuneCountInString(workPackage.Status)
 		statusStr := fmt.Sprintf("[%s]%s", Yellow(workPackage.Status), indent(diff))
 		parts = append(parts, statusStr)
 	}

--- a/components/printer/work_packages_test.go
+++ b/components/printer/work_packages_test.go
@@ -93,6 +93,44 @@ func TestWorkPackage_Assignee_With_Empty_String(t *testing.T) {
 	}
 }
 
+func TestWorkPackages_WithAccentedCharacters(t *testing.T) {
+	testingPrinter.Reset()
+
+	// The bug: len() counts bytes, not runes. Accented chars (â, é...) are 2 bytes but 1 rune.
+	// The misalignment only appears when the string that determines the max column width
+	// has NO accented chars, while another string does.
+	// Here "User Story" (10 runes, 10 bytes) sets maxTypeLength, while "Tâche" (5 runes, 6 bytes)
+	// gets one space too few with the broken code (diff=10-6=4 instead of correct 10-5=5).
+	workPackages := []*models.WorkPackage{
+		{
+			Id:      2,
+			Subject: "Subject A",
+			Type:    "Tâche",
+			Status:  "En cours",
+		},
+		{
+			Id:      10,
+			Subject: "Subject B",
+			Type:    "User Story",
+			Status:  "En cours de spécification",
+		},
+	}
+
+	var expected string
+
+	// maxTypeLength = max(5, 10) = 10 → "TÂCHE" gets 5 trailing spaces
+	// maxStatusLength = max(8, 25) = 25 → "En cours" gets 17 trailing spaces
+	// id #2 = 2 chars, #10 = 3 chars → 1 leading space for #2
+	expected += fmt.Sprintf("%s %s [%s]                  %s\n", printer.Red(" #2"), printer.Green("TÂCHE     "), printer.Yellow("En cours"), printer.Cyan("Subject A"))
+	expected += fmt.Sprintf("%s %s [%s] %s\n", printer.Red("#10"), printer.Green("USER STORY"), printer.Yellow("En cours de spécification"), printer.Cyan("Subject B"))
+
+	printer.WorkPackages(workPackages)
+
+	if testingPrinter.Result != expected {
+		t.Errorf("\nExpected:\n%sbut got:\n%s", expected, testingPrinter.Result)
+	}
+}
+
 func TestWorkPackages(t *testing.T) {
 	testingPrinter.Reset()
 


### PR DESCRIPTION
Use utf8.RuneCountInString instead of len() to compute column widths, so that accented characters (é, â, à...) are counted as 1 display character instead of 2 bytes.

Add a regression test that catches the misalignment.
