### PR TITLE
added flags functionality to login-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ Open a new shell and completion should work by using the `TAB` key as usual.
 The OpenProject CLI commands are structured in a common, human-readable pattern. Every command is built
 as `op VERB RESOURCE [additional information]`. You will see plenty of examples within this section.
 
+### Login
+
+You are able to login interactively to your openproject instance by running:
+```shell
+op login
+```
+
+The login command takes the optional flags `--host` and `--api-key` in order to login non-interactively:
+```shell
+op login --host https://openproject.org --api-key aaaaabbbbbccccdddddeeeeefffffggggghhhhhiiiiijjjjjkkkkklllllmmmmm
+```
+
 ### Discoverability
 
 Discoverability is key. As we won't document every single command within this README, it is important for the CLI tool,

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -26,9 +26,15 @@ var loginCmd = &cobra.Command{
 	Long: `Enables the login flow, which enables the user to use
 this tool for a specific OpenProject instance. The login
 needs the host URL of the OpenProject instance and a
-generated API token.`,
+generated API token. You can provide both with flags to
+skip interactive input.`,
 	Run: login,
 }
+
+var (
+	loginHostFlag   string
+	loginAPIKeyFlag string
+)
 
 const (
 	urlInputError      = "There was a problem parsing the input. Please try again and put in a valid URL."
@@ -41,51 +47,84 @@ func login(_ *cobra.Command, _ []string) {
 	var hostUrl *url.URL
 	var token string
 
-	for {
-		printer.Debug(Verbose, "Parsing host URL ...")
-		printer.Input("OpenProject host URL: ")
-
-		ok, msg, host := parseHostUrl()
+	if loginHostFlag != "" {
+		printer.Debug(Verbose, "Parsing host URL from --host ...")
+		ok, msg, host := parseHostUrlInput(loginHostFlag)
 		if !ok {
 			printer.ErrorText(msg)
-			continue
+			return
 		}
 
 		printer.Debug(Verbose, "Initializing requests client ...")
 		requests.Init(host, "", Verbose)
-		ok = checkOpenProjectApi()
-		if !ok {
+		if !checkOpenProjectApi() {
 			printer.ErrorText(noOpInstanceError)
-			continue
+			return
 		}
 
 		hostUrl = host
-		break
+	} else {
+		for {
+			printer.Debug(Verbose, "Parsing host URL ...")
+			printer.Input("OpenProject host URL: ")
+
+			ok, msg, host := parseHostUrl()
+			if !ok {
+				printer.ErrorText(msg)
+				continue
+			}
+
+			printer.Debug(Verbose, "Initializing requests client ...")
+			requests.Init(host, "", Verbose)
+			ok = checkOpenProjectApi()
+			if !ok {
+				printer.ErrorText(noOpInstanceError)
+				continue
+			}
+
+			hostUrl = host
+			break
+		}
 	}
 
-	for {
-		fmt.Printf("OpenProject API Token (Visit %s/my/access_tokens to generate one): ", hostUrl)
-		ok, t := requestApiToken()
-		if !ok {
-			fmt.Println(tokenInputError)
-			continue
-		}
-
-		token = common.SanitizeLineBreaks(t)
-
+	if loginAPIKeyFlag != "" {
+		token = common.SanitizeLineBreaks(loginAPIKeyFlag)
 		requests.Init(hostUrl, token, Verbose)
 		user, err := users.Me()
 		if err != nil {
 			printer.Error(err)
-			continue
+			return
 		}
 
 		if user.Name == "Anonymous" {
 			printer.ErrorText("no authenticate given")
-			continue
+			return
 		}
+	} else {
+		for {
+			fmt.Printf("OpenProject API Token (Visit %s/my/access_tokens to generate one): ", hostUrl)
+			ok, t := requestApiToken()
+			if !ok {
+				fmt.Println(tokenInputError)
+				continue
+			}
 
-		break
+			token = common.SanitizeLineBreaks(t)
+
+			requests.Init(hostUrl, token, Verbose)
+			user, err := users.Me()
+			if err != nil {
+				printer.Error(err)
+				continue
+			}
+
+			if user.Name == "Anonymous" {
+				printer.ErrorText("no authenticate given")
+				continue
+			}
+
+			break
+		}
 	}
 
 	storeLoginData(hostUrl, token)
@@ -99,6 +138,11 @@ func parseHostUrl() (ok bool, errMessage string, host *url.URL) {
 		printer.Debug(Verbose, fmt.Sprintf("Error reading string input: %+v", err))
 		return false, urlInputError, nil
 	}
+
+	return parseHostUrlInput(input)
+}
+
+func parseHostUrlInput(input string) (ok bool, errMessage string, host *url.URL) {
 
 	printer.Debug(Verbose, fmt.Sprintf("Parsed input %q.", input))
 	printer.Debug(Verbose, "Sanitizing input ...")
@@ -124,6 +168,22 @@ func parseHostUrl() (ok bool, errMessage string, host *url.URL) {
 
 	printer.Debug(Verbose, "Parsing input successful, continuing with next steps.")
 	return true, "", parsed
+}
+
+func init() {
+	loginCmd.Flags().StringVar(
+		&loginHostFlag,
+		"host",
+		"",
+		"OpenProject host URL",
+	)
+
+	loginCmd.Flags().StringVar(
+		&loginAPIKeyFlag,
+		"api-key",
+		"",
+		"OpenProject API token",
+	)
 }
 
 func checkOpenProjectApi() bool {


### PR DESCRIPTION
# Ticket
No ticket availalbe for this at https://community.openproject.org/projects/cli/work_packages 

# What are you trying to accomplish?
Add the flags `--host`and `--api-key` to the login command in order to be able to login automatically via .bashrc for example.

## Screenshots
N/A

# What approach did you choose and why?
I needed to be able to sign in automatically on starting a shell, adding the flags to login.go seemed to be the best solution.

# Merge checklist

- [ ] Added/updated tests - No added tests, code passes `go test -v ./... `
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) - N/A
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) - N/A
